### PR TITLE
[기능]

### DIFF
--- a/src/main/java/com/icia/hexagon/Config/Security/SpringSecurityConfig.java
+++ b/src/main/java/com/icia/hexagon/Config/Security/SpringSecurityConfig.java
@@ -25,7 +25,7 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         http.csrf().disable()
                 .authorizeRequests()
-                .antMatchers("/", "/member/save", "/member/login", "/member/dup-check", "/css/**", "/images/**").permitAll()  // 인증(로그인) 없이 접근 허용
+                .antMatchers("/", "/member/save", "/member/login", "/member/dup-check", "/css/**", "/images/**", "/game").permitAll()  // 인증(로그인) 없이 접근 허용
                 .antMatchers(HttpMethod.PUT, "/member/update/**").authenticated()
                 .antMatchers(HttpMethod.DELETE, "/member/delete/**").authenticated()
                 .anyRequest().authenticated()  // 나머지 요청은 인증된 사용자만 접근 가능

--- a/src/main/java/com/icia/hexagon/Controller/MemberController.java
+++ b/src/main/java/com/icia/hexagon/Controller/MemberController.java
@@ -63,7 +63,8 @@ public class MemberController {
     public String findAll(@PageableDefault(page=1)Pageable pageable,
                           @RequestParam(value="type", required=false, defaultValue = "")String type,
                           @RequestParam(value="q", required = false, defaultValue = "")String q,
-                          Model model){
+                          Model model,
+                          @AuthenticationPrincipal User user){
         Page<MemberDTO> memberDTOPage = memberService.paging(pageable, type, q);
         if(memberDTOPage.getTotalElements()==0){
             model.addAttribute("memberList", null);
@@ -78,7 +79,11 @@ public class MemberController {
         model.addAttribute("endPage", endPage);
         model.addAttribute("type", type);
         model.addAttribute("q", q);
-        return "/memberPages/memberList";
+        if(user.getUsername() == "admin") {
+            return "/memberPages/memberList";
+        } else {
+            return "redirect:/";
+        }
     }
 
     @GetMapping("/login")


### PR DESCRIPTION
1. 게임 주소에 대한 인증 없이 접근을 허용하도록 설정
2. 회원목록을 관리자만 접속할 수 있게 설정

[설명]
1. Spring Security의 configure 메소드에서 .antMatchers를 사용하여 "/game" 주소에 대한 인증 없이 접근할 수 있도록 설정

2. findAll 메소드에서 @AuthenticationPrincipal 어노테이션을 사용하여 user.getUsername()이 "admin"인 경우에만 회원 목록 페이지에 접근할 수 있도록 설정

[수정 사항]
1. SpringSecurityConfig 클래스의 configure 메소드에 .antMatchers("/game")를 추가

2. MemberController 클래스의 findAll 메소드에 @AuthenticationPrincipal 어노테이션을 추가하고, 조건문을 사용하여 user.getUsername()이 "admin"인 경우에만 회원 목록 페이지에 접근할 수 있도록 변경